### PR TITLE
[UPDATE] WebConfig에서 IP 주소를 EC2의 IP로 설정

### DIFF
--- a/src/main/java/com/example/PING/WebConfig.java
+++ b/src/main/java/com/example/PING/WebConfig.java
@@ -7,7 +7,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final String ipAddress = "localhost"; // 또는 실제 IP 주소
+//    private final String ipAddress = "localhost"; // 로컬 테스트용 IP
+    private final String ipAddress = "43.203.51.237"; // CI/CD 배포를 위한 IP 주소
     private final String frontEndPort = "5173"; // React 앱이 실행되는 포트
 
 


### PR DESCRIPTION
백엔드 CI/CD 배포 시 container 실행되지 않는 무제 해결을 위한 수정